### PR TITLE
Remove rbac proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove kube-rbac-proxy for the metrics endpoint.
 
+### Fixed
+
+- Fixed label selector for webhook and manager services.
+
 ## [0.3.14-gs2] - 2021-05-27
 
 ## [0.3.14-gs1] - 2021-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove kube-rbac-proxy for the metrics endpoint.
+
 ## [0.3.14-gs2] - 2021-05-27
 
 ## [0.3.14-gs1] - 2021-05-12

--- a/helm/cluster-api-control-plane/templates/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/deployment.yaml
@@ -19,21 +19,7 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.rbacproxy.image.name }}:{{ .Values.rbacproxy.image.tag }}"
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=8080:8080
         - --watch-filter={{ .Values.watchfilter }}
         command:
         - /manager

--- a/helm/cluster-api-control-plane/templates/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
         image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: IfNotPresent
         name: manager
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
       dnsPolicy: ClusterFirst

--- a/helm/cluster-api-control-plane/templates/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-addr=8080:8080
+        - --metrics-addr=0.0.0.0:8080
         - --watch-filter={{ .Values.watchfilter }}
         command:
         - /manager

--- a/helm/cluster-api-control-plane/templates/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/deployment.yaml
@@ -9,12 +9,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
+      control-plane: controller-manager
       {{- include "labels.selector" . | nindent 6 }}
   template:
     metadata:
       annotations:
         releaseRevision: {{ .Release.Revision | quote }}
       labels:
+        control-plane: controller-manager
         {{- include "labels.common" . | nindent 8 }}
     spec:
       containers:

--- a/helm/cluster-api-control-plane/templates/rbac.yaml
+++ b/helm/cluster-api-control-plane/templates/rbac.yaml
@@ -67,28 +67,6 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: control-plane-kubeadm
-    clusterctl.cluster.x-k8s.io: ''
-    {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy-role
-rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -104,20 +82,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    cluster.x-k8s.io/provider: control-plane-kubeadm
-    clusterctl.cluster.x-k8s.io: ''
-    {{- include "labels.common" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "resource.default.name" . }}-proxy-role
-subjects:
-- kind: ServiceAccount
-  name: {{ include "resource.default.name" . }}
-  namespace: {{ include "resource.default.namespace" . }}
+

--- a/helm/cluster-api-control-plane/templates/service.yaml
+++ b/helm/cluster-api-control-plane/templates/service.yaml
@@ -10,10 +10,10 @@ metadata:
   namespace: {{ include "resource.default.namespace" . }}
 spec:
   ports:
-  - name: http
+  - name: metrics
     port: 8080
     protocol: TCP
-    targetPort: http
+    targetPort: metrics
   selector:
     {{- include "labels.selector" . | nindent 4 }}
     control-plane: controller-manager

--- a/helm/cluster-api-control-plane/templates/service.yaml
+++ b/helm/cluster-api-control-plane/templates/service.yaml
@@ -16,5 +16,6 @@ spec:
     targetPort: http
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    control-plane: controller-manager
   sessionAffinity: None
   type: ClusterIP

--- a/helm/cluster-api-control-plane/templates/service.yaml
+++ b/helm/cluster-api-control-plane/templates/service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
-  labels:
     giantswarm.io/monitoring: "true"
+  labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-metrics-service
   namespace: {{ include "resource.default.namespace" . }}

--- a/helm/cluster-api-control-plane/templates/service.yaml
+++ b/helm/cluster-api-control-plane/templates/service.yaml
@@ -10,10 +10,10 @@ metadata:
   namespace: {{ include "resource.default.namespace" . }}
 spec:
   ports:
-  - name: https
-    port: 8443
+  - name: http
+    port: 8080
     protocol: TCP
-    targetPort: https
+    targetPort: http
   selector:
     {{- include "labels.selector" . | nindent 4 }}
   sessionAffinity: None

--- a/helm/cluster-api-control-plane/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/webhook/deployment.yaml
@@ -11,10 +11,12 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
+      control-plane: webhook
   template:
     metadata:
       labels:
         {{- include "labels.common" . | nindent 8 }}
+        control-plane: webhook
     spec:
       containers:
       - args:

--- a/helm/cluster-api-control-plane/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-control-plane/templates/webhook/deployment.yaml
@@ -20,17 +20,7 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.rbacproxy.image.name }}:{{ .Values.rbacproxy.image.tag }}"
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=0.0.0.0:8080
         - --webhook-port=9443
         command:
         - /manager

--- a/helm/cluster-api-control-plane/templates/webhook/service.yaml
+++ b/helm/cluster-api-control-plane/templates/webhook/service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "8080"
   name: {{ include "resource.default.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
 spec:

--- a/helm/cluster-api-control-plane/templates/webhook/service.yaml
+++ b/helm/cluster-api-control-plane/templates/webhook/service.yaml
@@ -14,3 +14,4 @@ spec:
     targetPort: webhook-server
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    control-plane: webhook

--- a/helm/cluster-api-control-plane/values.yaml
+++ b/helm/cluster-api-control-plane/values.yaml
@@ -2,10 +2,6 @@ name: cluster-api
 image:
   name: giantswarm/kubeadm-control-plane-controller
   tag: bb90d2037f840c82ee2fd61a181699b94bbbb53e
-rbacproxy:
-  image:
-    name: giantswarm/kube-rbac-proxy
-    tag: v0.4.1
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
According to upstream direction (https://github.com/kubernetes-sigs/cluster-api/issues/4679) this PR removes the rbac proxy from the metrics endpoint.
We don't use it anywhere else and it's just better to not have it for conformity